### PR TITLE
Merge 170519

### DIFF
--- a/applyFilter.sh
+++ b/applyFilter.sh
@@ -54,5 +54,12 @@ echo "#$VTAG FILTER=$(basename $FILTER)" >>$MAFOUT
 TMPMAF=$(uuidgen).maf
 
 $FILTER -m $MAFIN -o $TMPMAF $*
+EXIT_CODE=$?
+
+if [ "$EXIT_CODE" != "0" ]; then
+    echo "ERROR IN R-script"
+    exit 1
+fi
+
 cat $TMPMAF >>$MAFOUT
 rm $TMPMAF

--- a/filter_cohort_normals.R
+++ b/filter_cohort_normals.R
@@ -6,19 +6,17 @@
 # annotate somatic variant calls accordingly
 ##########################################################################################
 
-annotate_maf <- function(maf, fillout,
-                         alt.reads = 3,
-                         normal.regex = NA) {
+annotate_maf <- function(maf, fillout, normal.samples, alt.reads = 3) {
 
   # select normal samples
-  if (!is.na(normal.regex)) {
-    fillout <- fillout[Tumor_Sample_Barcode %like% normal]
-  } else {
-    fillout <- fillout[Tumor_Sample_Barcode %like% "*N$"]
-  }
+  fillout <- fillout[Tumor_Sample_Barcode %in% normal.samples]
 
   # identify loci with 3+ alternate reads in any normal sample
   fillout <- fillout[t_alt_count >= alt.reads]
+
+  if(nrow(fillout)==0){
+    cat("**WARNING** cohort normal fillout empty. Check normal samples or normal.regex=r/",normal.regex,"/\n")
+  }
 
   # Add TAG to MAF
   if (!('TAG' %in% names(maf))) {
@@ -58,6 +56,8 @@ if( ! interactive() ) {
   parser$add_argument('-f', '--fillout', type='character', help='FILLOUT.vep.maf file')
   parser$add_argument('-n', '--reads', type='character', default=3, help='Alternate read threshold')
   parser$add_argument('-o', '--outfile', type='character', help='Output file', default = 'stdout')
+  parser$add_argument('-r', '--regex', type='character', help='RegEx for normals', default = '')
+  parser$add_argument('-N', '--normalSamplesFile', type='character', help='File with list of normal samples', default='')
   args=parser$parse_args()
 
   if (args$maf == 'stdin') { maf = suppressWarnings(fread('cat /dev/stdin', showProgress = F))
@@ -65,8 +65,25 @@ if( ! interactive() ) {
   fillout <- suppressWarnings(fread(args$fillout, showProgress = F))
   alt.reads <- args$reads
   outfile <- args$outfile
+  normal.regex <- args$regex
+  normalSamplesFile <- args$normalSamplesFile
 
-  maf.out <- annotate_maf(maf, fillout)
-  if (outfile == 'stdout') { write.table(maf.out, stdout(), sep = "\t", col.names = T, row.names = F, quote = F)
-  } else { write.table(maf.out, outfile, sep = "\t", col.names = T, row.names = F, quote = F) }
+  # get normal samples
+
+  if(normalSamplesFile!="") {
+
+    normal.samples=scan(normalSamplesFile,"")
+
+  } else {
+
+    fillout.samples=unique(fillout$Tumor_Sample_Barcode)
+    if (normal.regex=="") {
+      normal.regex="*N$"
+    }
+    normal.samples=fillout.samples[grepl(normal.regex,fillout.samples)]
+  }
+
+  maf.out <- annotate_maf(maf, fillout, normal.samples)
+  if (outfile == 'stdout') { write.table(maf.out, stdout(), sep = "\t", col.names = T, row.names = F, quote = F, na="")
+  } else { write.table(maf.out, outfile, sep = "\t", col.names = T, row.names = F, quote = F, na="") }
 }


### PR DESCRIPTION
_N.B._ My mac tower client has an old key so I am showing up as _bic-mskcc_ instead of _soccin_. I will fix this before submitting any more pull requests

I have a bunch of changes which I have had in my local version of wes-filters that I would like to roll into the master branch. The most complex were changes to filter_cohort_normals.R  to allow for more flexible ways to specify what the normal samples in the cohort were. I added to additional command line options 

- `-r|--regex` to set the regEx used to detect normals. This was actually in the code but there was no way to set it. 

- `-N|--normalSamplesFile` to specify a file of sample ID's to explicit define the normals in the cohort. 

To get both of these to work I moved the detection of normal samples out of the `annotate_maf` function and instead pass to it the list of normals and get the normal samples in the main block

I also changed the na option on write.table to set NA->""

I also added code to `applyFilter.sh` to check the exit code of the filter script and exit with 1 if it was non-zero. 